### PR TITLE
Apply patch we've been carrying in op-build

### DIFF
--- a/palmetto.xml
+++ b/palmetto.xml
@@ -2685,6 +2685,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+	        <id>BMC_FRU_ID</id>
+	        <default>15</default>
+	</attribute>
+	<attribute>
 		<id>FRU_NAME</id>
 		<default></default>
 	</attribute>


### PR DESCRIPTION
```
$ git log openpower/package/palmetto-xml/palmetto-xml-0002-Add-Sys-Fw-Fru-Id.patch
commit ffe83706f87d9d9e9e860fc5f0032d0aa113e76d
Author: Bill Hoffa <wghoffa@us.ibm.com>
Date:   Mon Mar 30 21:37:20 2015 -0500

    Habanero Updates for SL
```

Which likely means nobody has boot tested a Palmetto system *without* this patch in over 2 years.

So, it should likely be in the palmetto-xml repo.