### PR TITLE
Fix IBSCOM_MCS_BASE_ADDR value

### DIFF
--- a/palmetto.xml
+++ b/palmetto.xml
@@ -5356,8 +5356,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -5408,8 +5407,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -5460,8 +5458,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -5512,8 +5509,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -6639,8 +6635,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -6691,8 +6686,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -6743,8 +6737,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
@@ -6795,8 +6788,7 @@
 	</attribute>
 	<attribute>
 		<id>IBSCOM_MCS_BASE_ADDR</id>
-		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-			</default>
+		<default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>


### PR DESCRIPTION
The whitespace was tripping up the xmltohb.pl script.

Signed-off-by: Joel Stanley <joel@jms.id.au>