### PR TITLE
Add Sys Fw Fru Id

### DIFF
--- a/palmetto.xml
+++ b/palmetto.xml
@@ -2685,6 +2685,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+	        <id>BMC_FRU_ID</id>
+	        <default>15</default>
+	</attribute>
+	<attribute>
 		<id>FRU_NAME</id>
 		<default></default>
 	</attribute>


### PR DESCRIPTION
This patch has been in the op-build tree since Marc 2015. Given we have always built palmetto with it, include it in the XML.